### PR TITLE
[Feat] 주식 상세 > 뉴스 목록 조회 및 CORS 설정 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,8 +9,11 @@ from openai_service import get_response
 from dateutil import parser
 from news_crawler import store_latest_news
 from news_crawler import fetch_latest_news
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app, resources={r"/*": {"origins": "http://localhost:3000"}})
+
 
 swagger = Swagger(app)
 

--- a/app.py
+++ b/app.py
@@ -8,19 +8,18 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from openai_service import get_response
 from dateutil import parser
 from news_crawler import store_latest_news
+from news_crawler import fetch_latest_news
 
 app = Flask(__name__)
 
 swagger = Swagger(app)
 
-# 회사명과 티커 매핑
 COMPANY_TICKERS = {
     "삼성전자": "005930.KS",
     "현대차": "005380.KS",
     "LG에너지솔루션": "373220.KQ"
 }
 
-# 주식 정보 Enum (시가, 최고가, 최저가, 종가, 거래량)
 STOCK_FIELDS = {
     "시가": "Open",
     "최고가": "High",
@@ -76,15 +75,12 @@ def get_stock_info():
         date = data.get("date")
         print(f"회사명: {company_name}, 주식 정보: {stock_field}, 날짜: {date}")
 
-        # 회사명 검증
         if company_name not in COMPANY_TICKERS:
             return jsonify({"error": f"지원하지 않는 회사입니다: {company_name}"}), 400
 
-        # 주식 정보 검증
         if stock_field not in STOCK_FIELDS:
             return jsonify({"error": f"지원하지 않는 정보입니다: {stock_field}"}), 400
 
-        # end 날짜 구하기
         try:
             start_date = parser.parse(date).date()
             formatted_date = start_date.strftime("%Y년 %m월 %d일")
@@ -137,19 +133,52 @@ def ask():
         description: 서버 에러
     """
     try:
-        # 요청 데이터에서 질문 추출
         data = request.json
         prompt = data.get("prompt", "")
 
         if not prompt:
             return jsonify({"error": "질문이 비어있습니다."}), 400
 
-        # OpenAI 응답 생성
         response = get_response(prompt)
         return jsonify({"response": response})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     
+from news_crawler import fetch_latest_news  # 이미 정의되어 있는 함수
+
+@app.route('/latest-news', methods=['GET'])
+def latest_news():
+    """
+    종목별 최신 뉴스 5개를 네이버 금융 뉴스 API에서 조회하는 API
+    ---
+    parameters:
+      - name: ticker
+        in: query
+        type: string
+        required: true
+        enum: ["삼성전자", "LG에너지솔루션", "SK하이닉스", "현대차", "비에이치아이"]
+        description: 종목 이름
+        example: "삼성전자"
+    responses:
+      200:
+        description: 뉴스 리스트 반환
+      400:
+        description: 유효하지 않은 ticker
+      500:
+        description: 서버 에러
+    """
+    try:
+        ticker_name = request.args.get("ticker")
+        if not ticker_name or ticker_name not in NEWS_TICKERS:
+            return jsonify({"error": f"지원하지 않는 ticker입니다: {ticker_name}"}), 400
+
+        ticker_code = NEWS_TICKERS[ticker_name]
+        news_items = fetch_latest_news(ticker_code)
+
+        return jsonify({"ticker": ticker_name, "news": news_items}), 200
+
+    except Exception as e:
+        return jsonify({"error": f"서버 에러: {str(e)}"}), 500
 
 @app.route('/flask/crawl-news', methods=['GET'])
 def crawl_news():
@@ -175,7 +204,6 @@ def crawl_news():
     try:
         ticker_name = request.args.get("ticker")
 
-        # ✅ 특정 종목 요청 처리
         if ticker_name and ticker_name not in NEWS_TICKERS:
             return jsonify({"error": f"Invalid ticker name: {ticker_name}"}), 400
         

--- a/essential_package.txt
+++ b/essential_package.txt
@@ -1,0 +1,14 @@
+Flask==3.0.0
+Flasgger==0.9.5
+requests==2.32.3
+yfinance==0.2.31
+bs4==0.0.2
+selenium==4.27.1
+webdriver-manager==4.0.2
+pandas==2.2.1
+python-dotenv==1.0.1
+openai==1.10.0
+langchain==0.1.12
+pinecone-client==3.0.2
+tiktoken==0.6.0
+dateutil==2.8.2

--- a/openai_service.py
+++ b/openai_service.py
@@ -5,8 +5,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# OpenAI API 설정
-api_key = os.getenv("OPENAI_API_KEY")  # .env 파일에서 API 키 로드
+api_key = os.getenv("OPENAI_API_KEY")  
 if not api_key:
     raise ValueError("OPENAI_API_KEY 환경 변수가 설정되지 않았습니다.")
 


### PR DESCRIPTION
## 💡 작업 내용

- 종목별 최신 뉴스 5개를 실시간으로 조회할 수 있는 `/latest-news` API를 구현했습니다.
  - 네이버 금융 뉴스 페이지에서 크롤링하여, 기사 제목/링크/날짜 정보를 제공합니다.
- `flask_cors`를 사용하여 **CORS 설정**을 추가했습니다.
  - 현재 `http://localhost:3000` 도메인에서 요청 가능하도록 허용되어 있습니다.

---

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

---

## 🙋🏻‍ 확인해주세요

- `/latest-news?ticker=삼성전자`와 같이 쿼리 파라미터로 종목명을 보내면 뉴스 5개가 응답됩니다.
- 이 기능은 추후 메인 서버에서 주식 상세 조회 시 연동될 예정입니다.